### PR TITLE
pcre > now boost::regex

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -20,6 +20,9 @@ CHECK_RELEASE = YES
 #  Must be either YES or NO.
 STATIC_BUILD=YES
 
+# Ensure we build both...
+SHARED_LIBRARIES=YES
+
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -22,12 +22,11 @@
 # the CONFIG_SITE file.
 
 # Variables and paths to dependent modules:
-#MODULES = /path/to/modules
-#MYMODULE = $(MODULES)/my-module
-BOOST=$(SUPPORT)/boost
-
-# EPICS_BASE should appear last so earlier modules can override stuff:
+SUPPORT=/usr/local/epics/support
 EPICS_BASE=/usr/local/epics/base
+#BOOST=$(EPICS_BASE)/libraries/master/boost
+BOOST=/usr/include/boost/
+BOOST_LIBS=/usr/include/boost/
 
 # Set RULES here if you want to use build rules from somewhere
 # other than EPICS_BASE:

--- a/utilitiesApp/src/Makefile
+++ b/utilitiesApp/src/Makefile
@@ -17,9 +17,6 @@ LIBRARY_IOC += utilities
 DBD += utilities.dbd
 INC += utilities.h
 
-#utils lib dependancy on boost
-utilities_SYS_LIBS += boost_regex
-
 # specify all source files to be compiled and added to the library
 utilities_SRCS += trimString.cpp mkdir.cpp iocshHelpers.cpp ioccalc.cpp iocdcalc.cpp iocstringtest.cpp
 utilities_SRCS += dbLoadRecordsFuncs.cpp iocshCmdFuncs.cpp iocname.cpp

--- a/utilitiesApp/src/Makefile
+++ b/utilitiesApp/src/Makefile
@@ -7,14 +7,18 @@ include $(TOP)/configure/CONFIG
 
 #==================================================
 # build a support library
+USR_INCLUDES += -I$(BOOST)
+USR_LDFLAGS  += -L$(BOOST_LIB)
 
-USR_INCLUDES += -I"/usr/local/lib" -I"/usr/local/epics/support/boost"
-
+#library name
 LIBRARY_IOC += utilities
 
 # install icpconfig.dbd into <top>/dbd
 DBD += utilities.dbd
 INC += utilities.h
+
+#utils lib dependancy on boost
+utilities_SYS_LIBS += boost_regex
 
 # specify all source files to be compiled and added to the library
 utilities_SRCS += trimString.cpp mkdir.cpp iocshHelpers.cpp ioccalc.cpp iocdcalc.cpp iocstringtest.cpp

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -1,7 +1,7 @@
-///
 /// @file dbLoadRecordsFuncs.cpp Enhanced EPICS dbLoadRecords functions
 /// @author Freddie Akeroyd, STFC ISIS Facility <freddie.akeroyd@stfc.ac.uk>
-///
+/// @amended Tim Speight, STFC CLF <timothy.speight@stfc.ac.uk>
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -41,47 +41,64 @@
 #include "envDefs.h"
 #include "macLib.h"
 #include "errlog.h"
-#include "pcrecpp.h"
+
+// --- PCRE redacted ---
+// #include "pcrecpp.h"
 
 #include <string.h>
-#include <regex>
-#include <registryFunction.h>
 
+// --- switch from <regex> to Boost.Regex ---
+#include <boost/regex.hpp>
+namespace re = boost;
+
+// iocsh / EPICS registry and export
+#include <registryFunction.h>
 #include <epicsExport.h>
 
 #include "utilities.h"
 
-/// load current environment into mac handle 
+/// load current environment into mac handle
 static void loadMacEnviron(MAC_HANDLE* pmh)
 {
-	for(char** cp = environ; *cp != NULL; ++cp)
-	{
-		char* str_tmp = strdup(*cp);
-		char* equals_loc = strchr(str_tmp, '='); // split   name=value   string
-		if (equals_loc != NULL)
-		{
-		    *equals_loc = '\0';
-		    macPutValue(pmh, str_tmp, equals_loc + 1);
-		}
-		free(str_tmp);
-	}
+    for (char** cp = environ; *cp != NULL; ++cp)
+    {
+        char* str_tmp = strdup(*cp);
+        char* equals_loc = strchr(str_tmp, '='); // split name=value string
+        if (equals_loc != NULL)
+        {
+            *equals_loc = '\0';
+            macPutValue(pmh, str_tmp, equals_loc + 1);
+        }
+        free(str_tmp);
+    }
 }
 
-/// look for e.g. \$() and replace with $() so we can substitute later with macEnvExpand()
+/// look for e.g. \$(...) or \${...} and replace with $(...) / ${...}
+/// so we can substitute later with macEnvExpand()
 void subMacros(std::string& new_macros, const char* macros)
 {
-    const std::regex bracketPattern = std::regex(R"(\\\$\(([0-9a-zA-Z_$(){}]+)\))");
-    const std::regex bracePattern = std::regex(R"(\\\$\{([0-9a-zA-Z_$(){}]+)\})");
-    new_macros = macros;
-    std::smatch bracketSearch, braceSearch;
-    // Check that we have done a search, and that the result of both is empty before finishing.
-    while((!bracketSearch.empty())||(!braceSearch.empty())||(!bracketSearch.ready())){
-        std::regex_search(new_macros, bracketSearch, bracketPattern);
-        new_macros = std::regex_replace(new_macros, bracketPattern, std::string("$($1)"));
-        // Have to look twice to guarantee that brackets/curly braces are properly matched.
-        std::regex_search(new_macros, braceSearch, bracePattern);
-        new_macros = std::regex_replace(new_macros, bracePattern, std::string("${$1}"));
-    }
+    new_macros = macros ? macros : std::string();
+
+    // Match a *literal* backslash followed by $(...) or ${...}
+    //  R"(\\\$\(([^)]+)\))"  ==  \$(...)
+    //  R"(\\\$\{([^}]+)\})"  ==  \${...}
+    const re::regex bracketPattern(R"(\\\$\(([^)]+)\))");
+    const re::regex bracePattern  (R"(\\\$\{([^}]+)\})");
+
+    re::smatch m1, m2;
+    bool changed;
+    do {
+        changed = false;
+
+        if (re::regex_search(new_macros, m1, bracketPattern)) {
+            new_macros = re::regex_replace(new_macros, bracketPattern, std::string("$($1)"));
+            changed = true;
+        }
+        if (re::regex_search(new_macros, m2, bracePattern)) {
+            new_macros = re::regex_replace(new_macros, bracePattern, std::string("${$1}"));
+            changed = true;
+        }
+    } while (changed);
 }
 
 /// Load a db file multiple times substituting a specified macro according to a number range.
@@ -96,16 +113,17 @@ void subMacros(std::string& new_macros, const char* macros)
 /// reference in an \\ escaped way to make sure EPICS does not try to substitute it too soon.
 /// as well as the \a macros the \a dbFile is also passed the \a loopVar macro value
 /// @code
-///     dbLoadRecordsLoop("file\$(I).db", "P=1,Q=Hello\$(I)", "I", 1, 4)
-/// @endcode 
+/// dbLoadRecordsLoop("file\$(I).db", "P=1,Q=Hello\$(I)", "I", 1, 4)
+/// @endcode
 ///
-/// @param[in] dbFile @copydoc dbLoadRecordsLoopInitArg0
-/// @param[in] macros @copydoc dbLoadRecordsLoopInitArg1
+/// @param[in] dbFile  @copydoc dbLoadRecordsLoopInitArg0
+/// @param[in] macros  @copydoc dbLoadRecordsLoopInitArg1
 /// @param[in] loopVar @copydoc dbLoadRecordsLoopInitArg2
-/// @param[in] start @copydoc dbLoadRecordsLoopInitArg3
-/// @param[in] stop @copydoc dbLoadRecordsLoopInitArg4
-/// @param[in] step @copydoc dbLoadRecordsLoopInitArg5
-epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, const char* loopVar, int start, int stop, int step)
+/// @param[in] start   @copydoc dbLoadRecordsLoopInitArg3
+/// @param[in] stop    @copydoc dbLoadRecordsLoopInitArg4
+/// @param[in] step    @copydoc dbLoadRecordsLoopInitArg5
+epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, const char* loopVar,
+                                      int start, int stop, int step)
 {
     char loopVal[32];
     if (loopVar == NULL)
@@ -120,24 +138,30 @@ epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, co
     std::string macros_s, dbFile_s;
     subMacros(macros_s, macros);
     subMacros(dbFile_s, dbFile);
+
     MAC_HANDLE* mh = NULL;
-	char macros_exp[1024], dbFile_exp[1024];
+    char macros_exp[1024], dbFile_exp[1024];
     macCreateHandle(&mh, NULL);
-	loadMacEnviron(mh);
-    for(int i = start; i <= stop; i += step)
+    loadMacEnviron(mh);
+
+    for (int i = start; i <= stop; i += step)
     {
-		macPushScope(mh);
+        macPushScope(mh);
         epicsSnprintf(loopVal, sizeof(loopVal), "%d", i);
-        macPutValue(mh, loopVar, loopVal);   
+        macPutValue(mh, loopVar, loopVal);
+
         macExpandString(mh, macros_s.c_str(), macros_exp, sizeof(macros_exp));
         macExpandString(mh, dbFile_s.c_str(), dbFile_exp, sizeof(dbFile_exp));
+
         std::ostringstream new_macros;
         new_macros << macros_exp << (strlen(macros_exp) > 0 ? "," : "") << loopVar << "=" << i;
-        std::cout << "--> (" << i << ") dbLoadRecords(\"" << dbFile_exp << "\",\"" << new_macros.str() << "\")" << std::endl;
+        std::cout << "--> (" << i << ") dbLoadRecords(\"" << dbFile_exp
+                  << "\",\"" << new_macros.str() << "\")" << std::endl;
+
         dbLoadRecords(dbFile_exp, new_macros.str().c_str());
-		macPopScope(mh);
+        macPopScope(mh);
     }
-	macDeleteHandle(mh);		
+    macDeleteHandle(mh);
 }
 
 /// Load a db file multiple times according to a list of items separated by known separator(s).
@@ -145,22 +169,23 @@ epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, co
 /// The \a dbFile and \a macros arguments are like the normal dbLoadRecords() however
 /// it is possible to embed a macro within these whose value takes a value from the \a list.
 /// You can either load the same \a dbFile multiple times with different macros, or even load
-/// different database files by using \a loopVar as part of the filename. If you want to use a 
+/// different database files by using \a loopVar as part of the filename. If you want to use a
 /// pure numeric range see dbLoadRecordsLoop()
 ///
 /// The name of the macro to be used for substitution is contained in \a loopVar and needs to be
 /// reference in an \\ escaped way to make sure EPICS does not try to substitute it too soon.
 /// as well as the \a macros the \a dbFile is also passed the \a loopVar macro value
 /// @code
-///     dbLoadRecordsList("file\$(S).db", "P=1,Q=Hello\$(S)", "S", "A;B;C", ";")
-/// @endcode 
+/// dbLoadRecordsList("file\$(S).db", "P=1,Q=Hello\$(S)", "S", "A;B;C", ";")
+/// @endcode
 ///
-/// @param[in] dbFile @copydoc dbLoadRecordsListInitArg0
-/// @param[in] macros @copydoc dbLoadRecordsListInitArg1
+/// @param[in] dbFile  @copydoc dbLoadRecordsListInitArg0
+/// @param[in] macros  @copydoc dbLoadRecordsListInitArg1
 /// @param[in] loopVar @copydoc dbLoadRecordsListInitArg2
-/// @param[in] list @copydoc dbLoadRecordsListInitArg3
-/// @param[in] sep @copydoc dbLoadRecordsListInitArg4
-epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, const char* loopVar, const char* list, const char* sep)
+/// @param[in] list    @copydoc dbLoadRecordsListInitArg3
+/// @param[in] sep     @copydoc dbLoadRecordsListInitArg4
+epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, const char* loopVar,
+                                      const char* list, const char* sep)
 {
     static const char* default_sep = ";";
     if (loopVar == NULL || list == NULL)
@@ -168,37 +193,41 @@ epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, co
         dbLoadRecords(dbFile, macros);
         return;
     }
-	if (sep == NULL)
-	{
-		sep = default_sep;
-	}
+    if (sep == NULL) sep = default_sep;
+
     std::string macros_s, dbFile_s;
     subMacros(macros_s, macros);
     subMacros(dbFile_s, dbFile);
+
     MAC_HANDLE* mh = NULL;
-	char macros_exp[1024], dbFile_exp[1024];
+    char macros_exp[1024], dbFile_exp[1024];
     macCreateHandle(&mh, NULL);
-	loadMacEnviron(mh);
+    loadMacEnviron(mh);
+
     char* saveptr = NULL;
     char* list_tmp = strdup(list);
     char* list_item = epicsStrtok_r(list_tmp, sep, &saveptr);
-    while(list_item != NULL)
+
+    while (list_item != NULL)
     {
-		macPushScope(mh);
-        macPutValue(mh, loopVar, list_item);   
+        macPushScope(mh);
+        macPutValue(mh, loopVar, list_item);
+
         macExpandString(mh, macros_s.c_str(), macros_exp, sizeof(macros_exp));
         macExpandString(mh, dbFile_s.c_str(), dbFile_exp, sizeof(dbFile_exp));
+
         std::ostringstream new_macros;
         new_macros << macros_exp << (strlen(macros_exp) > 0 ? "," : "") << loopVar << "=" << list_item;
-        std::cout << "--> (" << list_item << ") dbLoadRecords(\"" << dbFile_exp << "\",\"" << new_macros.str() << "\")" << std::endl;
+        std::cout << "--> (" << list_item << ") dbLoadRecords(\"" << dbFile_exp
+                  << "\",\"" << new_macros.str() << "\")" << std::endl;
+
         dbLoadRecords(dbFile_exp, new_macros.str().c_str());
         list_item = epicsStrtok_r(NULL, sep, &saveptr);
-		macPopScope(mh);
+        macPopScope(mh);
     }
     free(list_tmp);
-	macDeleteHandle(mh);		
+    macDeleteHandle(mh);
 }
-
 
 /// Create an alias for all records starting with prefix \a recordPrefix by replacing this with \a aliasPrefix
 ///
@@ -208,29 +237,33 @@ epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, co
 /// So if a piece of movable equipoment was being used locally and its PVs/autosave were all set
 /// up in the ME: domain, then aliases for local use could be created using
 /// @code
-///     dbAliasRecordsPrefix("ME:", "$(MYPVPREFIX)")
-/// @endcode 
+/// dbAliasRecordsPrefix("ME:", "$(MYPVPREFIX)")
+/// @endcode
 ///
 /// @param[in] recordPrefix @copydoc dbAliasRecordsPrefixInitArg0
-/// @param[in] aliasPrefix @copydoc dbAliasRecordsPrefixInitArg1
-/// @param[in] verbose @copydoc dbAliasRecordsPrefixInitArg2
+/// @param[in] aliasPrefix  @copydoc dbAliasRecordsPrefixInitArg1
+/// @param[in] verbose      @copydoc dbAliasRecordsPrefixInitArg2
 epicsShareFunc void dbAliasRecordsPrefix(const char* recordPrefix, const char* aliasPrefix, int verbose)
 {
     if (!*aliasPrefix || !*recordPrefix) {
         return;
     }
+
     size_t nprefix = strlen(recordPrefix);
     DBENTRY dbentry;
     DBENTRY *pdbentry=&dbentry;
     long status;
+
     if (!pdbbase) {
         throw std::runtime_error("No database loaded\n");
     }
+
     dbInitEntry(pdbbase, pdbentry);
     status = dbFirstRecordType(pdbentry);
     if (status) {
         return;
     }
+
     int n = 0;
     while (!status) {
         status = dbFirstRecord(pdbentry);
@@ -239,14 +272,16 @@ epicsShareFunc void dbAliasRecordsPrefix(const char* recordPrefix, const char* a
                 std::string alias_str(aliasPrefix);
                 alias_str += (dbGetRecordName(pdbentry) + nprefix);
                 if (dbCreateAlias(pdbentry, alias_str.c_str())) {
-                    epicsPrintf("dbAliasRecordsPrefix: Can't create alias %s -> %s\n", alias_str.c_str(), dbGetRecordName(pdbentry));
+                    epicsPrintf("dbAliasRecordsPrefix: Can't create alias %s -> %s\n",
+                                alias_str.c_str(), dbGetRecordName(pdbentry));
                 } else {
                     if (verbose) {
-                        epicsPrintf("dbAliasRecordsPrefix: %s -> %s\n", alias_str.c_str(), dbGetRecordName(pdbentry));
+                        epicsPrintf("dbAliasRecordsPrefix: %s -> %s\n",
+                                    alias_str.c_str(), dbGetRecordName(pdbentry));
                     } else if (++n % 10000 == 0) {
                         epicsPrintf("dbAliasRecordsPrefix: created %d aliases so far...\n", n);
                     }
-                }                    
+                }
             }
             status = dbNextRecord(pdbentry);
         }
@@ -261,46 +296,64 @@ epicsShareFunc void dbAliasRecordsPrefix(const char* recordPrefix, const char* a
 /// This is a bit like having an alias gateway, but without needing to run a gateway.
 /// It could be extended to only prefix records with e.g. a particular info field present
 ///
-/// So if a piece of movable equipoment was being used locally and its PVs/autosave were all set
-/// up in the ME: domain, then aliases for local use could be created using
+/// Example:
 /// @code
-///     dbAliasRecordsRE("ME:(.*)", "$(MYPVPREFIX)\1")
-/// @endcode 
+/// dbAliasRecordsRE("ME:(.*)", "$(MYPVPREFIX)\\1")
+/// @endcode
 ///
 /// @param[in] recordMatch @copydoc dbAliasRecordsREInitArg0
-/// @param[in] aliasSub @copydoc dbAliasRecordsREInitArg1
-/// @param[in] verbose @copydoc dbAliasRecordsREInitArg2
+/// @param[in] aliasSub    @copydoc dbAliasRecordsREInitArg1
+/// @param[in] verbose     @copydoc dbAliasRecordsREInitArg2
 epicsShareFunc void dbAliasRecordsRE(const char* recordMatch, const char* aliasSub, int verbose)
 {
     if (!*aliasSub || !*recordMatch) {
         return;
     }
-    pcrecpp::RE re(recordMatch);
-    std::string s;
+
+    // --- PCRE redacted; use Boost.Regex instead ---
+    re::regex rx;
+    try {
+        rx.assign(recordMatch);
+    } catch (const std::exception& ex) {
+        epicsPrintf("dbAliasRecordsRE: bad regex '%s': %s\n", recordMatch, ex.what());
+        return;
+    }
+
+    std::string s, aliased;
     DBENTRY dbentry;
     DBENTRY *pdbentry=&dbentry;
     long status;
+
     if (!pdbbase) {
         throw std::runtime_error("No database loaded\n");
     }
+
     dbInitEntry(pdbbase, pdbentry);
     status = dbFirstRecordType(pdbentry);
     if (status) {
         return;
     }
+
     int n = 0;
     while (!status) {
         status = dbFirstRecord(pdbentry);
         while (!status) {
             s = dbGetRecordName(pdbentry);
-            if ( re.FullMatch(s) && re.Replace(aliasSub, &s) ) {
-                if (dbCreateAlias(pdbentry, s.c_str())) {
-                    epicsPrintf("dbAliasRecordsRE: Can't create alias %s -> %s\n", s.c_str(), dbGetRecordName(pdbentry));
-                } else {
-                    if (verbose) {
-                        epicsPrintf("dbAliasRecordsRE: %s -> %s\n", s.c_str(), dbGetRecordName(pdbentry));
-                    } else if (++n % 10000 == 0) {
-                        epicsPrintf("dbAliasRecordsRE: created %d aliases so far...\n", n);
+
+            // Keep original semantics: full-string match then apply substitution
+            if (re::regex_match(s, rx)) {
+                aliased = re::regex_replace(s, rx, std::string(aliasSub));
+                if (!aliased.empty() && aliased != s) {
+                    if (dbCreateAlias(pdbentry, aliased.c_str())) {
+                        epicsPrintf("dbAliasRecordsRE: Can't create alias %s -> %s\n",
+                                    aliased.c_str(), dbGetRecordName(pdbentry));
+                    } else {
+                        if (verbose) {
+                            epicsPrintf("dbAliasRecordsRE: %s -> %s\n",
+                                        aliased.c_str(), dbGetRecordName(pdbentry));
+                        } else if (++n % 10000 == 0) {
+                            epicsPrintf("dbAliasRecordsRE: created %d aliases so far...\n", n);
+                        }
                     }
                 }
             }
@@ -313,59 +366,58 @@ epicsShareFunc void dbAliasRecordsRE(const char* recordMatch, const char* aliasS
 }
 
 extern "C" {
+// EPICS iocsh shell commands
+static const iocshArg dbLoadRecordsLoopInitArg0 = { "dbFile",  iocshArgString };   ///< DB filename
+static const iocshArg dbLoadRecordsLoopInitArg1 = { "macros",  iocshArgString };   ///< macros to pass to \a dbFile
+static const iocshArg dbLoadRecordsLoopInitArg2 = { "loopVar", iocshArgString };   ///< loop macro variable name
+static const iocshArg dbLoadRecordsLoopInitArg3 = { "start",   iocshArgInt    };   ///< start loop value
+static const iocshArg dbLoadRecordsLoopInitArg4 = { "stop",    iocshArgInt    };   ///< end loop value
+static const iocshArg dbLoadRecordsLoopInitArg5 = { "step",    iocshArgInt    };   ///< loop step (default: 1)
+static const iocshArg * const dbLoadRecordsLoopInitArgs[] =
+    { &dbLoadRecordsLoopInitArg0, &dbLoadRecordsLoopInitArg1,
+      &dbLoadRecordsLoopInitArg2, &dbLoadRecordsLoopInitArg3,
+      &dbLoadRecordsLoopInitArg4, &dbLoadRecordsLoopInitArg5 };
 
-// EPICS iocsh shell commands 
+static const iocshArg dbLoadRecordsListInitArg0 = { "dbFile",  iocshArgString };   ///< DB filename
+static const iocshArg dbLoadRecordsListInitArg1 = { "macros",  iocshArgString };   ///< macros to pass to \a dbFile
+static const iocshArg dbLoadRecordsListInitArg2 = { "loopVar", iocshArgString };   ///< list macro variable name
+static const iocshArg dbLoadRecordsListInitArg3 = { "list",    iocshArgString };   ///< list of values to substitute
+static const iocshArg dbLoadRecordsListInitArg4 = { "sep",     iocshArgString };   ///< \a list value separator character
+static const iocshArg * const dbLoadRecordsListInitArgs[] =
+    { &dbLoadRecordsListInitArg0, &dbLoadRecordsListInitArg1,
+      &dbLoadRecordsListInitArg2, &dbLoadRecordsListInitArg3, &dbLoadRecordsListInitArg4 };
 
-static const iocshArg dbLoadRecordsLoopInitArg0 = { "dbFile", iocshArgString };			///< DB filename
-static const iocshArg dbLoadRecordsLoopInitArg1 = { "macros", iocshArgString };			///< macros to pass to \a dbFile
-static const iocshArg dbLoadRecordsLoopInitArg2 = { "loopVar", iocshArgString };	    ///< loop macro variable name
-static const iocshArg dbLoadRecordsLoopInitArg3 = { "start", iocshArgInt };			///< start loop value
-static const iocshArg dbLoadRecordsLoopInitArg4 = { "stop", iocshArgInt };			///< end loop value
-static const iocshArg dbLoadRecordsLoopInitArg5 = { "step", iocshArgInt };			///< loop step (default: 1)
-static const iocshArg * const dbLoadRecordsLoopInitArgs[] = { &dbLoadRecordsLoopInitArg0, &dbLoadRecordsLoopInitArg1,
-     &dbLoadRecordsLoopInitArg2, &dbLoadRecordsLoopInitArg3, &dbLoadRecordsLoopInitArg4, &dbLoadRecordsLoopInitArg5 };
+static const iocshArg dbAliasRecordsPrefixInitArg0 = { "recordPrefix", iocshArgString }; ///< prefix of records that we wish to alias
+static const iocshArg dbAliasRecordsPrefixInitArg1 = { "aliasPrefix",  iocshArgString }; ///< what to replace \a recordPrefix with
+static const iocshArg dbAliasRecordsPrefixInitArg2 = { "verbose",      iocshArgInt    }; ///< set to 1 to print out aliases created
+static const iocshArg * const dbAliasRecordsPrefixInitArgs[] =
+    { &dbAliasRecordsPrefixInitArg0, &dbAliasRecordsPrefixInitArg1, &dbAliasRecordsPrefixInitArg2 };
 
-static const iocshArg dbLoadRecordsListInitArg0 = { "dbFile", iocshArgString };			///< DB filename
-static const iocshArg dbLoadRecordsListInitArg1 = { "macros", iocshArgString };			///< macros to pass to \a dbFile
-static const iocshArg dbLoadRecordsListInitArg2 = { "loopVar", iocshArgString };			///< list macro variable name
-static const iocshArg dbLoadRecordsListInitArg3 = { "list", iocshArgString };			///< list of values to substitute
-static const iocshArg dbLoadRecordsListInitArg4 = { "sep", iocshArgString };			///< \a list value separator character
-static const iocshArg * const dbLoadRecordsListInitArgs[] = { &dbLoadRecordsListInitArg0, &dbLoadRecordsListInitArg1,
-     &dbLoadRecordsListInitArg2, &dbLoadRecordsListInitArg3, &dbLoadRecordsListInitArg4 };
+static const iocshArg dbAliasRecordsREInitArg0 = { "recordMatch", iocshArgString }; ///< pattern of records that we wish to alias
+static const iocshArg dbAliasRecordsREInitArg1 = { "aliasSub",    iocshArgString }; ///< what to substitute \a recordMatch with
+static const iocshArg dbAliasRecordsREInitArg2 = { "verbose",     iocshArgInt    }; ///< set to 1 to print out aliases created
+static const iocshArg * const dbAliasRecordsREInitArgs[] =
+    { &dbAliasRecordsREInitArg0, &dbAliasRecordsREInitArg1, &dbAliasRecordsREInitArg2 };
 
-static const iocshArg dbAliasRecordsPrefixInitArg0 = { "recordPrefix", iocshArgString };   ///< prefix of records that we wish to alias
-static const iocshArg dbAliasRecordsPrefixInitArg1 = { "aliasPrefix", iocshArgString };    ///< what to replace \a recordPrefix with
-static const iocshArg dbAliasRecordsPrefixInitArg2 = { "verbose", iocshArgInt };           ///< set to 1 to print out aliases created
-static const iocshArg * const dbAliasRecordsPrefixInitArgs[] = { &dbAliasRecordsPrefixInitArg0, &dbAliasRecordsPrefixInitArg1, &dbAliasRecordsPrefixInitArg2 };
-
-static const iocshArg dbAliasRecordsREInitArg0 = { "recordMatch", iocshArgString };   ///< pattern of records that we wish to alias
-static const iocshArg dbAliasRecordsREInitArg1 = { "aliasSub", iocshArgString };      ///< what to substitute \a recordMatch with
-static const iocshArg dbAliasRecordsREInitArg2 = { "verbose", iocshArgInt };          ///< set to 1 to print out aliases created
-static const iocshArg * const dbAliasRecordsREInitArgs[] = { &dbAliasRecordsREInitArg0, &dbAliasRecordsREInitArg1, &dbAliasRecordsREInitArg2 };
-
-static const iocshFuncDef dbLoadRecordsLoopDef = {"dbLoadRecordsLoop", sizeof(dbLoadRecordsLoopInitArgs) / sizeof(iocshArg*), dbLoadRecordsLoopInitArgs};
-
-static const iocshFuncDef dbLoadRecordsListDef = {"dbLoadRecordsList", sizeof(dbLoadRecordsListInitArgs) / sizeof(iocshArg*), dbLoadRecordsListInitArgs};
-
-static const iocshFuncDef dbAliasRecordsPrefixDef = {"dbAliasRecordsPrefix", sizeof(dbAliasRecordsPrefixInitArgs) / sizeof(iocshArg*), dbAliasRecordsPrefixInitArgs};
-
-static const iocshFuncDef dbAliasRecordsREDef = {"dbAliasRecordsRE", sizeof(dbAliasRecordsREInitArgs) / sizeof(iocshArg*), dbAliasRecordsREInitArgs};
+static const iocshFuncDef dbLoadRecordsLoopDef   = {"dbLoadRecordsLoop",   sizeof(dbLoadRecordsLoopInitArgs)/sizeof(iocshArg*), dbLoadRecordsLoopInitArgs};
+static const iocshFuncDef dbLoadRecordsListDef   = {"dbLoadRecordsList",   sizeof(dbLoadRecordsListInitArgs)/sizeof(iocshArg*), dbLoadRecordsListInitArgs};
+static const iocshFuncDef dbAliasRecordsPrefixDef= {"dbAliasRecordsPrefix",sizeof(dbAliasRecordsPrefixInitArgs)/sizeof(iocshArg*), dbAliasRecordsPrefixInitArgs};
+static const iocshFuncDef dbAliasRecordsREDef    = {"dbAliasRecordsRE",    sizeof(dbAliasRecordsREInitArgs)/sizeof(iocshArg*), dbAliasRecordsREInitArgs};
 
 static void dbLoadRecordsLoopInitCallFunc(const iocshArgBuf *args)
 {
-    dbLoadRecordsLoop(args[0].sval, args[1].sval, args[2].sval, args[3].ival, args[4].ival, args[5].ival);
+    dbLoadRecordsLoop(args[0].sval, args[1].sval, args[2].sval,
+                      args[3].ival, args[4].ival, args[5].ival);
 }
-
 static void dbLoadRecordsListInitCallFunc(const iocshArgBuf *args)
 {
-    dbLoadRecordsList(args[0].sval, args[1].sval, args[2].sval, args[3].sval, args[4].sval);
+    dbLoadRecordsList(args[0].sval, args[1].sval, args[2].sval,
+                      args[3].sval, args[4].sval);
 }
-
 static void dbAliasRecordsPrefixInitCallFunc(const iocshArgBuf *args)
 {
     dbAliasRecordsPrefix(args[0].sval, args[1].sval, args[2].ival);
 }
-
 static void dbAliasRecordsREInitCallFunc(const iocshArgBuf *args)
 {
     dbAliasRecordsRE(args[0].sval, args[1].sval, args[2].ival);
@@ -373,12 +425,10 @@ static void dbAliasRecordsREInitCallFunc(const iocshArgBuf *args)
 
 static void dbLoadRecordsFuncsRegister(void)
 {
-    iocshRegister(&dbLoadRecordsLoopDef, dbLoadRecordsLoopInitCallFunc);
-    iocshRegister(&dbLoadRecordsListDef, dbLoadRecordsListInitCallFunc);
+    iocshRegister(&dbLoadRecordsLoopDef,    dbLoadRecordsLoopInitCallFunc);
+    iocshRegister(&dbLoadRecordsListDef,    dbLoadRecordsListInitCallFunc);
     iocshRegister(&dbAliasRecordsPrefixDef, dbAliasRecordsPrefixInitCallFunc);
-    iocshRegister(&dbAliasRecordsREDef, dbAliasRecordsREInitCallFunc);
+    iocshRegister(&dbAliasRecordsREDef,     dbAliasRecordsREInitCallFunc);
 }
-
 epicsExportRegistrar(dbLoadRecordsFuncsRegister); // need to be declared via registrar() in utilities.dbd too
-
-}
+} // extern "C"

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -1,7 +1,7 @@
+///
 /// @file dbLoadRecordsFuncs.cpp Enhanced EPICS dbLoadRecords functions
 /// @author Freddie Akeroyd, STFC ISIS Facility <freddie.akeroyd@stfc.ac.uk>
-/// @amended Tim Speight, STFC CLF <timothy.speight@stfc.ac.uk>
-
+///
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -43,59 +43,44 @@
 #include "errlog.h"
 
 #include <string.h>
-
-// --- switch from <regex> to Boost.Regex ---
-#include <boost/regex.hpp>
-namespace re = boost;
-
-// iocsh / EPICS registry and export
+#include <regex>
 #include <registryFunction.h>
+
 #include <epicsExport.h>
 
 #include "utilities.h"
 
-/// load current environment into mac handle
+/// load current environment into mac handle 
 static void loadMacEnviron(MAC_HANDLE* pmh)
 {
-    for (char** cp = environ; *cp != NULL; ++cp)
-    {
-        char* str_tmp = strdup(*cp);
-        char* equals_loc = strchr(str_tmp, '='); // split name=value string
-        if (equals_loc != NULL)
-        {
-            *equals_loc = '\0';
-            macPutValue(pmh, str_tmp, equals_loc + 1);
-        }
-        free(str_tmp);
-    }
+	for(char** cp = environ; *cp != NULL; ++cp)
+	{
+		char* str_tmp = strdup(*cp);
+		char* equals_loc = strchr(str_tmp, '='); // split   name=value   string
+		if (equals_loc != NULL)
+		{
+		    *equals_loc = '\0';
+		    macPutValue(pmh, str_tmp, equals_loc + 1);
+		}
+		free(str_tmp);
+	}
 }
 
-/// look for e.g. \$(...) or \${...} and replace with $(...) / ${...}
-/// so we can substitute later with macEnvExpand()
+/// look for e.g. \$() and replace with $() so we can substitute later with macEnvExpand()
 void subMacros(std::string& new_macros, const char* macros)
 {
-    new_macros = macros ? macros : std::string();
-
-    // Match a *literal* backslash followed by $(...) or ${...}
-    //  R"(\\\$\(([^)]+)\))"  ==  \$(...)
-    //  R"(\\\$\{([^}]+)\})"  ==  \${...}
-    const re::regex bracketPattern(R"(\\\$\(([^)]+)\))");
-    const re::regex bracePattern  (R"(\\\$\{([^}]+)\})");
-
-    re::smatch m1, m2;
-    bool changed;
-    do {
-        changed = false;
-
-        if (re::regex_search(new_macros, m1, bracketPattern)) {
-            new_macros = re::regex_replace(new_macros, bracketPattern, std::string("$($1)"));
-            changed = true;
-        }
-        if (re::regex_search(new_macros, m2, bracePattern)) {
-            new_macros = re::regex_replace(new_macros, bracePattern, std::string("${$1}"));
-            changed = true;
-        }
-    } while (changed);
+    const std::regex bracketPattern = std::regex(R"(\\\$\(([0-9a-zA-Z_$(){}]+)\))");
+    const std::regex bracePattern = std::regex(R"(\\\$\{([0-9a-zA-Z_$(){}]+)\})");
+    new_macros = macros;
+    std::smatch bracketSearch, braceSearch;
+    // Check that we have done a search, and that the result of both is empty before finishing.
+    while((!bracketSearch.empty())||(!braceSearch.empty())||(!bracketSearch.ready())){
+        std::regex_search(new_macros, bracketSearch, bracketPattern);
+        new_macros = std::regex_replace(new_macros, bracketPattern, std::string("$($1)"));
+        // Have to look twice to guarantee that brackets/curly braces are properly matched.
+        std::regex_search(new_macros, braceSearch, bracePattern);
+        new_macros = std::regex_replace(new_macros, bracePattern, std::string("${$1}"));
+    }
 }
 
 /// Load a db file multiple times substituting a specified macro according to a number range.
@@ -110,17 +95,16 @@ void subMacros(std::string& new_macros, const char* macros)
 /// reference in an \\ escaped way to make sure EPICS does not try to substitute it too soon.
 /// as well as the \a macros the \a dbFile is also passed the \a loopVar macro value
 /// @code
-/// dbLoadRecordsLoop("file\$(I).db", "P=1,Q=Hello\$(I)", "I", 1, 4)
-/// @endcode
+///     dbLoadRecordsLoop("file\$(I).db", "P=1,Q=Hello\$(I)", "I", 1, 4)
+/// @endcode 
 ///
-/// @param[in] dbFile  @copydoc dbLoadRecordsLoopInitArg0
-/// @param[in] macros  @copydoc dbLoadRecordsLoopInitArg1
+/// @param[in] dbFile @copydoc dbLoadRecordsLoopInitArg0
+/// @param[in] macros @copydoc dbLoadRecordsLoopInitArg1
 /// @param[in] loopVar @copydoc dbLoadRecordsLoopInitArg2
-/// @param[in] start   @copydoc dbLoadRecordsLoopInitArg3
-/// @param[in] stop    @copydoc dbLoadRecordsLoopInitArg4
-/// @param[in] step    @copydoc dbLoadRecordsLoopInitArg5
-epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, const char* loopVar,
-                                      int start, int stop, int step)
+/// @param[in] start @copydoc dbLoadRecordsLoopInitArg3
+/// @param[in] stop @copydoc dbLoadRecordsLoopInitArg4
+/// @param[in] step @copydoc dbLoadRecordsLoopInitArg5
+epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, const char* loopVar, int start, int stop, int step)
 {
     char loopVal[32];
     if (loopVar == NULL)
@@ -135,30 +119,24 @@ epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, co
     std::string macros_s, dbFile_s;
     subMacros(macros_s, macros);
     subMacros(dbFile_s, dbFile);
-
     MAC_HANDLE* mh = NULL;
-    char macros_exp[1024], dbFile_exp[1024];
+	char macros_exp[1024], dbFile_exp[1024];
     macCreateHandle(&mh, NULL);
-    loadMacEnviron(mh);
-
-    for (int i = start; i <= stop; i += step)
+	loadMacEnviron(mh);
+    for(int i = start; i <= stop; i += step)
     {
-        macPushScope(mh);
+		macPushScope(mh);
         epicsSnprintf(loopVal, sizeof(loopVal), "%d", i);
-        macPutValue(mh, loopVar, loopVal);
-
+        macPutValue(mh, loopVar, loopVal);   
         macExpandString(mh, macros_s.c_str(), macros_exp, sizeof(macros_exp));
         macExpandString(mh, dbFile_s.c_str(), dbFile_exp, sizeof(dbFile_exp));
-
         std::ostringstream new_macros;
         new_macros << macros_exp << (strlen(macros_exp) > 0 ? "," : "") << loopVar << "=" << i;
-        std::cout << "--> (" << i << ") dbLoadRecords(\"" << dbFile_exp
-                  << "\",\"" << new_macros.str() << "\")" << std::endl;
-
+        std::cout << "--> (" << i << ") dbLoadRecords(\"" << dbFile_exp << "\",\"" << new_macros.str() << "\")" << std::endl;
         dbLoadRecords(dbFile_exp, new_macros.str().c_str());
-        macPopScope(mh);
+		macPopScope(mh);
     }
-    macDeleteHandle(mh);
+	macDeleteHandle(mh);		
 }
 
 /// Load a db file multiple times according to a list of items separated by known separator(s).
@@ -166,23 +144,22 @@ epicsShareFunc void dbLoadRecordsLoop(const char* dbFile, const char* macros, co
 /// The \a dbFile and \a macros arguments are like the normal dbLoadRecords() however
 /// it is possible to embed a macro within these whose value takes a value from the \a list.
 /// You can either load the same \a dbFile multiple times with different macros, or even load
-/// different database files by using \a loopVar as part of the filename. If you want to use a
+/// different database files by using \a loopVar as part of the filename. If you want to use a 
 /// pure numeric range see dbLoadRecordsLoop()
 ///
 /// The name of the macro to be used for substitution is contained in \a loopVar and needs to be
 /// reference in an \\ escaped way to make sure EPICS does not try to substitute it too soon.
 /// as well as the \a macros the \a dbFile is also passed the \a loopVar macro value
 /// @code
-/// dbLoadRecordsList("file\$(S).db", "P=1,Q=Hello\$(S)", "S", "A;B;C", ";")
-/// @endcode
+///     dbLoadRecordsList("file\$(S).db", "P=1,Q=Hello\$(S)", "S", "A;B;C", ";")
+/// @endcode 
 ///
-/// @param[in] dbFile  @copydoc dbLoadRecordsListInitArg0
-/// @param[in] macros  @copydoc dbLoadRecordsListInitArg1
+/// @param[in] dbFile @copydoc dbLoadRecordsListInitArg0
+/// @param[in] macros @copydoc dbLoadRecordsListInitArg1
 /// @param[in] loopVar @copydoc dbLoadRecordsListInitArg2
-/// @param[in] list    @copydoc dbLoadRecordsListInitArg3
-/// @param[in] sep     @copydoc dbLoadRecordsListInitArg4
-epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, const char* loopVar,
-                                      const char* list, const char* sep)
+/// @param[in] list @copydoc dbLoadRecordsListInitArg3
+/// @param[in] sep @copydoc dbLoadRecordsListInitArg4
+epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, const char* loopVar, const char* list, const char* sep)
 {
     static const char* default_sep = ";";
     if (loopVar == NULL || list == NULL)
@@ -190,41 +167,37 @@ epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, co
         dbLoadRecords(dbFile, macros);
         return;
     }
-    if (sep == NULL) sep = default_sep;
-
+	if (sep == NULL)
+	{
+		sep = default_sep;
+	}
     std::string macros_s, dbFile_s;
     subMacros(macros_s, macros);
     subMacros(dbFile_s, dbFile);
-
     MAC_HANDLE* mh = NULL;
-    char macros_exp[1024], dbFile_exp[1024];
+	char macros_exp[1024], dbFile_exp[1024];
     macCreateHandle(&mh, NULL);
-    loadMacEnviron(mh);
-
+	loadMacEnviron(mh);
     char* saveptr = NULL;
     char* list_tmp = strdup(list);
     char* list_item = epicsStrtok_r(list_tmp, sep, &saveptr);
-
-    while (list_item != NULL)
+    while(list_item != NULL)
     {
-        macPushScope(mh);
-        macPutValue(mh, loopVar, list_item);
-
+		macPushScope(mh);
+        macPutValue(mh, loopVar, list_item);   
         macExpandString(mh, macros_s.c_str(), macros_exp, sizeof(macros_exp));
         macExpandString(mh, dbFile_s.c_str(), dbFile_exp, sizeof(dbFile_exp));
-
         std::ostringstream new_macros;
         new_macros << macros_exp << (strlen(macros_exp) > 0 ? "," : "") << loopVar << "=" << list_item;
-        std::cout << "--> (" << list_item << ") dbLoadRecords(\"" << dbFile_exp
-                  << "\",\"" << new_macros.str() << "\")" << std::endl;
-
+        std::cout << "--> (" << list_item << ") dbLoadRecords(\"" << dbFile_exp << "\",\"" << new_macros.str() << "\")" << std::endl;
         dbLoadRecords(dbFile_exp, new_macros.str().c_str());
         list_item = epicsStrtok_r(NULL, sep, &saveptr);
-        macPopScope(mh);
+		macPopScope(mh);
     }
     free(list_tmp);
-    macDeleteHandle(mh);
+	macDeleteHandle(mh);		
 }
+
 
 /// Create an alias for all records starting with prefix \a recordPrefix by replacing this with \a aliasPrefix
 ///
@@ -234,33 +207,29 @@ epicsShareFunc void dbLoadRecordsList(const char* dbFile, const char* macros, co
 /// So if a piece of movable equipoment was being used locally and its PVs/autosave were all set
 /// up in the ME: domain, then aliases for local use could be created using
 /// @code
-/// dbAliasRecordsPrefix("ME:", "$(MYPVPREFIX)")
-/// @endcode
+///     dbAliasRecordsPrefix("ME:", "$(MYPVPREFIX)")
+/// @endcode 
 ///
 /// @param[in] recordPrefix @copydoc dbAliasRecordsPrefixInitArg0
-/// @param[in] aliasPrefix  @copydoc dbAliasRecordsPrefixInitArg1
-/// @param[in] verbose      @copydoc dbAliasRecordsPrefixInitArg2
+/// @param[in] aliasPrefix @copydoc dbAliasRecordsPrefixInitArg1
+/// @param[in] verbose @copydoc dbAliasRecordsPrefixInitArg2
 epicsShareFunc void dbAliasRecordsPrefix(const char* recordPrefix, const char* aliasPrefix, int verbose)
 {
     if (!*aliasPrefix || !*recordPrefix) {
         return;
     }
-
     size_t nprefix = strlen(recordPrefix);
     DBENTRY dbentry;
     DBENTRY *pdbentry=&dbentry;
     long status;
-
     if (!pdbbase) {
         throw std::runtime_error("No database loaded\n");
     }
-
     dbInitEntry(pdbbase, pdbentry);
     status = dbFirstRecordType(pdbentry);
     if (status) {
         return;
     }
-
     int n = 0;
     while (!status) {
         status = dbFirstRecord(pdbentry);
@@ -269,16 +238,14 @@ epicsShareFunc void dbAliasRecordsPrefix(const char* recordPrefix, const char* a
                 std::string alias_str(aliasPrefix);
                 alias_str += (dbGetRecordName(pdbentry) + nprefix);
                 if (dbCreateAlias(pdbentry, alias_str.c_str())) {
-                    epicsPrintf("dbAliasRecordsPrefix: Can't create alias %s -> %s\n",
-                                alias_str.c_str(), dbGetRecordName(pdbentry));
+                    epicsPrintf("dbAliasRecordsPrefix: Can't create alias %s -> %s\n", alias_str.c_str(), dbGetRecordName(pdbentry));
                 } else {
                     if (verbose) {
-                        epicsPrintf("dbAliasRecordsPrefix: %s -> %s\n",
-                                    alias_str.c_str(), dbGetRecordName(pdbentry));
+                        epicsPrintf("dbAliasRecordsPrefix: %s -> %s\n", alias_str.c_str(), dbGetRecordName(pdbentry));
                     } else if (++n % 10000 == 0) {
                         epicsPrintf("dbAliasRecordsPrefix: created %d aliases so far...\n", n);
                     }
-                }
+                }                    
             }
             status = dbNextRecord(pdbentry);
         }
@@ -293,64 +260,47 @@ epicsShareFunc void dbAliasRecordsPrefix(const char* recordPrefix, const char* a
 /// This is a bit like having an alias gateway, but without needing to run a gateway.
 /// It could be extended to only prefix records with e.g. a particular info field present
 ///
-/// Example:
+/// So if a piece of movable equipoment was being used locally and its PVs/autosave were all set
+/// up in the ME: domain, then aliases for local use could be created using
 /// @code
-/// dbAliasRecordsRE("ME:(.*)", "$(MYPVPREFIX)\\1")
-/// @endcode
+///     dbAliasRecordsRE("ME:(.*)", "$(MYPVPREFIX)\1")
+/// @endcode 
 ///
 /// @param[in] recordMatch @copydoc dbAliasRecordsREInitArg0
-/// @param[in] aliasSub    @copydoc dbAliasRecordsREInitArg1
-/// @param[in] verbose     @copydoc dbAliasRecordsREInitArg2
+/// @param[in] aliasSub @copydoc dbAliasRecordsREInitArg1
+/// @param[in] verbose @copydoc dbAliasRecordsREInitArg2
 epicsShareFunc void dbAliasRecordsRE(const char* recordMatch, const char* aliasSub, int verbose)
 {
     if (!*aliasSub || !*recordMatch) {
         return;
     }
-
-    // --- PCRE redacted; use Boost.Regex instead ---
-    re::regex rx;
-    try {
-        rx.assign(recordMatch);
-    } catch (const std::exception& ex) {
-        epicsPrintf("dbAliasRecordsRE: bad regex '%s': %s\n", recordMatch, ex.what());
-        return;
-    }
-
-    std::string s, aliased;
+    const std::regex re(recordMatch);
+    std::string s;
     DBENTRY dbentry;
     DBENTRY *pdbentry=&dbentry;
     long status;
-
     if (!pdbbase) {
         throw std::runtime_error("No database loaded\n");
     }
-
     dbInitEntry(pdbbase, pdbentry);
     status = dbFirstRecordType(pdbentry);
     if (status) {
         return;
     }
-
     int n = 0;
     while (!status) {
         status = dbFirstRecord(pdbentry);
         while (!status) {
             s = dbGetRecordName(pdbentry);
-
-            // Keep original semantics: full-string match then apply substitution
-            if (re::regex_match(s, rx)) {
-                aliased = re::regex_replace(s, rx, std::string(aliasSub));
-                if (!aliased.empty() && aliased != s) {
-                    if (dbCreateAlias(pdbentry, aliased.c_str())) {
-                        epicsPrintf("dbAliasRecordsRE: Can't create alias %s -> %s\n",
-                                    aliased.c_str(), dbGetRecordName(pdbentry));
-                    } else {
-                        if (verbose) {
-                            epicsPrintf("dbAliasRecordsRE: %s -> %s\n",
-                                        aliased.c_str(), dbGetRecordName(pdbentry));
-                        } else if (++n % 10000 == 0) {
-                            epicsPrintf("dbAliasRecordsRE: created %d aliases so far...\n", n);
-                        }
+            if ( std::regex_match(s, re) ) {
+                s = std::regex_replace(s, re, aliasSub);
+                if (dbCreateAlias(pdbentry, s.c_str())) {
+                    epicsPrintf("dbAliasRecordsRE: Can't create alias %s -> %s\n", s.c_str(), dbGetRecordName(pdbentry));
+                } else {
+                    if (verbose) {
+                        epicsPrintf("dbAliasRecordsRE: %s -> %s\n", s.c_str(), dbGetRecordName(pdbentry));
+                    } else if (++n % 10000 == 0) {
+                        epicsPrintf("dbAliasRecordsRE: created %d aliases so far...\n", n);
                     }
                 }
             }
@@ -363,58 +313,59 @@ epicsShareFunc void dbAliasRecordsRE(const char* recordMatch, const char* aliasS
 }
 
 extern "C" {
-// EPICS iocsh shell commands
-static const iocshArg dbLoadRecordsLoopInitArg0 = { "dbFile",  iocshArgString };   ///< DB filename
-static const iocshArg dbLoadRecordsLoopInitArg1 = { "macros",  iocshArgString };   ///< macros to pass to \a dbFile
-static const iocshArg dbLoadRecordsLoopInitArg2 = { "loopVar", iocshArgString };   ///< loop macro variable name
-static const iocshArg dbLoadRecordsLoopInitArg3 = { "start",   iocshArgInt    };   ///< start loop value
-static const iocshArg dbLoadRecordsLoopInitArg4 = { "stop",    iocshArgInt    };   ///< end loop value
-static const iocshArg dbLoadRecordsLoopInitArg5 = { "step",    iocshArgInt    };   ///< loop step (default: 1)
-static const iocshArg * const dbLoadRecordsLoopInitArgs[] =
-    { &dbLoadRecordsLoopInitArg0, &dbLoadRecordsLoopInitArg1,
-      &dbLoadRecordsLoopInitArg2, &dbLoadRecordsLoopInitArg3,
-      &dbLoadRecordsLoopInitArg4, &dbLoadRecordsLoopInitArg5 };
 
-static const iocshArg dbLoadRecordsListInitArg0 = { "dbFile",  iocshArgString };   ///< DB filename
-static const iocshArg dbLoadRecordsListInitArg1 = { "macros",  iocshArgString };   ///< macros to pass to \a dbFile
-static const iocshArg dbLoadRecordsListInitArg2 = { "loopVar", iocshArgString };   ///< list macro variable name
-static const iocshArg dbLoadRecordsListInitArg3 = { "list",    iocshArgString };   ///< list of values to substitute
-static const iocshArg dbLoadRecordsListInitArg4 = { "sep",     iocshArgString };   ///< \a list value separator character
-static const iocshArg * const dbLoadRecordsListInitArgs[] =
-    { &dbLoadRecordsListInitArg0, &dbLoadRecordsListInitArg1,
-      &dbLoadRecordsListInitArg2, &dbLoadRecordsListInitArg3, &dbLoadRecordsListInitArg4 };
+// EPICS iocsh shell commands 
 
-static const iocshArg dbAliasRecordsPrefixInitArg0 = { "recordPrefix", iocshArgString }; ///< prefix of records that we wish to alias
-static const iocshArg dbAliasRecordsPrefixInitArg1 = { "aliasPrefix",  iocshArgString }; ///< what to replace \a recordPrefix with
-static const iocshArg dbAliasRecordsPrefixInitArg2 = { "verbose",      iocshArgInt    }; ///< set to 1 to print out aliases created
-static const iocshArg * const dbAliasRecordsPrefixInitArgs[] =
-    { &dbAliasRecordsPrefixInitArg0, &dbAliasRecordsPrefixInitArg1, &dbAliasRecordsPrefixInitArg2 };
+static const iocshArg dbLoadRecordsLoopInitArg0 = { "dbFile", iocshArgString };			///< DB filename
+static const iocshArg dbLoadRecordsLoopInitArg1 = { "macros", iocshArgString };			///< macros to pass to \a dbFile
+static const iocshArg dbLoadRecordsLoopInitArg2 = { "loopVar", iocshArgString };	    ///< loop macro variable name
+static const iocshArg dbLoadRecordsLoopInitArg3 = { "start", iocshArgInt };			///< start loop value
+static const iocshArg dbLoadRecordsLoopInitArg4 = { "stop", iocshArgInt };			///< end loop value
+static const iocshArg dbLoadRecordsLoopInitArg5 = { "step", iocshArgInt };			///< loop step (default: 1)
+static const iocshArg * const dbLoadRecordsLoopInitArgs[] = { &dbLoadRecordsLoopInitArg0, &dbLoadRecordsLoopInitArg1,
+     &dbLoadRecordsLoopInitArg2, &dbLoadRecordsLoopInitArg3, &dbLoadRecordsLoopInitArg4, &dbLoadRecordsLoopInitArg5 };
 
-static const iocshArg dbAliasRecordsREInitArg0 = { "recordMatch", iocshArgString }; ///< pattern of records that we wish to alias
-static const iocshArg dbAliasRecordsREInitArg1 = { "aliasSub",    iocshArgString }; ///< what to substitute \a recordMatch with
-static const iocshArg dbAliasRecordsREInitArg2 = { "verbose",     iocshArgInt    }; ///< set to 1 to print out aliases created
-static const iocshArg * const dbAliasRecordsREInitArgs[] =
-    { &dbAliasRecordsREInitArg0, &dbAliasRecordsREInitArg1, &dbAliasRecordsREInitArg2 };
+static const iocshArg dbLoadRecordsListInitArg0 = { "dbFile", iocshArgString };			///< DB filename
+static const iocshArg dbLoadRecordsListInitArg1 = { "macros", iocshArgString };			///< macros to pass to \a dbFile
+static const iocshArg dbLoadRecordsListInitArg2 = { "loopVar", iocshArgString };			///< list macro variable name
+static const iocshArg dbLoadRecordsListInitArg3 = { "list", iocshArgString };			///< list of values to substitute
+static const iocshArg dbLoadRecordsListInitArg4 = { "sep", iocshArgString };			///< \a list value separator character
+static const iocshArg * const dbLoadRecordsListInitArgs[] = { &dbLoadRecordsListInitArg0, &dbLoadRecordsListInitArg1,
+     &dbLoadRecordsListInitArg2, &dbLoadRecordsListInitArg3, &dbLoadRecordsListInitArg4 };
 
-static const iocshFuncDef dbLoadRecordsLoopDef   = {"dbLoadRecordsLoop",   sizeof(dbLoadRecordsLoopInitArgs)/sizeof(iocshArg*), dbLoadRecordsLoopInitArgs};
-static const iocshFuncDef dbLoadRecordsListDef   = {"dbLoadRecordsList",   sizeof(dbLoadRecordsListInitArgs)/sizeof(iocshArg*), dbLoadRecordsListInitArgs};
-static const iocshFuncDef dbAliasRecordsPrefixDef= {"dbAliasRecordsPrefix",sizeof(dbAliasRecordsPrefixInitArgs)/sizeof(iocshArg*), dbAliasRecordsPrefixInitArgs};
-static const iocshFuncDef dbAliasRecordsREDef    = {"dbAliasRecordsRE",    sizeof(dbAliasRecordsREInitArgs)/sizeof(iocshArg*), dbAliasRecordsREInitArgs};
+static const iocshArg dbAliasRecordsPrefixInitArg0 = { "recordPrefix", iocshArgString };   ///< prefix of records that we wish to alias
+static const iocshArg dbAliasRecordsPrefixInitArg1 = { "aliasPrefix", iocshArgString };    ///< what to replace \a recordPrefix with
+static const iocshArg dbAliasRecordsPrefixInitArg2 = { "verbose", iocshArgInt };           ///< set to 1 to print out aliases created
+static const iocshArg * const dbAliasRecordsPrefixInitArgs[] = { &dbAliasRecordsPrefixInitArg0, &dbAliasRecordsPrefixInitArg1, &dbAliasRecordsPrefixInitArg2 };
+
+static const iocshArg dbAliasRecordsREInitArg0 = { "recordMatch", iocshArgString };   ///< pattern of records that we wish to alias
+static const iocshArg dbAliasRecordsREInitArg1 = { "aliasSub", iocshArgString };      ///< what to substitute \a recordMatch with
+static const iocshArg dbAliasRecordsREInitArg2 = { "verbose", iocshArgInt };          ///< set to 1 to print out aliases created
+static const iocshArg * const dbAliasRecordsREInitArgs[] = { &dbAliasRecordsREInitArg0, &dbAliasRecordsREInitArg1, &dbAliasRecordsREInitArg2 };
+
+static const iocshFuncDef dbLoadRecordsLoopDef = {"dbLoadRecordsLoop", sizeof(dbLoadRecordsLoopInitArgs) / sizeof(iocshArg*), dbLoadRecordsLoopInitArgs};
+
+static const iocshFuncDef dbLoadRecordsListDef = {"dbLoadRecordsList", sizeof(dbLoadRecordsListInitArgs) / sizeof(iocshArg*), dbLoadRecordsListInitArgs};
+
+static const iocshFuncDef dbAliasRecordsPrefixDef = {"dbAliasRecordsPrefix", sizeof(dbAliasRecordsPrefixInitArgs) / sizeof(iocshArg*), dbAliasRecordsPrefixInitArgs};
+
+static const iocshFuncDef dbAliasRecordsREDef = {"dbAliasRecordsRE", sizeof(dbAliasRecordsREInitArgs) / sizeof(iocshArg*), dbAliasRecordsREInitArgs};
 
 static void dbLoadRecordsLoopInitCallFunc(const iocshArgBuf *args)
 {
-    dbLoadRecordsLoop(args[0].sval, args[1].sval, args[2].sval,
-                      args[3].ival, args[4].ival, args[5].ival);
+    dbLoadRecordsLoop(args[0].sval, args[1].sval, args[2].sval, args[3].ival, args[4].ival, args[5].ival);
 }
+
 static void dbLoadRecordsListInitCallFunc(const iocshArgBuf *args)
 {
-    dbLoadRecordsList(args[0].sval, args[1].sval, args[2].sval,
-                      args[3].sval, args[4].sval);
+    dbLoadRecordsList(args[0].sval, args[1].sval, args[2].sval, args[3].sval, args[4].sval);
 }
+
 static void dbAliasRecordsPrefixInitCallFunc(const iocshArgBuf *args)
 {
     dbAliasRecordsPrefix(args[0].sval, args[1].sval, args[2].ival);
 }
+
 static void dbAliasRecordsREInitCallFunc(const iocshArgBuf *args)
 {
     dbAliasRecordsRE(args[0].sval, args[1].sval, args[2].ival);
@@ -422,10 +373,12 @@ static void dbAliasRecordsREInitCallFunc(const iocshArgBuf *args)
 
 static void dbLoadRecordsFuncsRegister(void)
 {
-    iocshRegister(&dbLoadRecordsLoopDef,    dbLoadRecordsLoopInitCallFunc);
-    iocshRegister(&dbLoadRecordsListDef,    dbLoadRecordsListInitCallFunc);
+    iocshRegister(&dbLoadRecordsLoopDef, dbLoadRecordsLoopInitCallFunc);
+    iocshRegister(&dbLoadRecordsListDef, dbLoadRecordsListInitCallFunc);
     iocshRegister(&dbAliasRecordsPrefixDef, dbAliasRecordsPrefixInitCallFunc);
-    iocshRegister(&dbAliasRecordsREDef,     dbAliasRecordsREInitCallFunc);
+    iocshRegister(&dbAliasRecordsREDef, dbAliasRecordsREInitCallFunc);
 }
+
 epicsExportRegistrar(dbLoadRecordsFuncsRegister); // need to be declared via registrar() in utilities.dbd too
-} // extern "C"
+
+}

--- a/utilitiesApp/src/dbLoadRecordsFuncs.cpp
+++ b/utilitiesApp/src/dbLoadRecordsFuncs.cpp
@@ -42,9 +42,6 @@
 #include "macLib.h"
 #include "errlog.h"
 
-// --- PCRE redacted ---
-// #include "pcrecpp.h"
-
 #include <string.h>
 
 // --- switch from <regex> to Boost.Regex ---


### PR DESCRIPTION
Please could you review my redaction.  Abhishek noted using utilities came with a forward dependancy for PCRE.  I really was struggling to build this last Friday with Hussam and PCRE was a major bug bear.  As this is a deviated subset from the head fork, I've chosen to pop the PCRE dependancy out - so we can just get using this.